### PR TITLE
Reproduce on a second GB10; correct image, SSM dtype, concurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ build inputs behind those numbers are in
 |---|---|
 | Target | `RadixArk/Qwen3.8-27B-NVFP4` @ `554ebba9` |
 | Draft | `z-lab/Qwen3.8-27B-DFlash2` @ `50307d4c` |
-| Image | `lmsysorg/sglang:qwen38-27b-dflash2` — **built locally (step 2)** |
+| Image | `lmsysorg/sglang:dev-cu13-qwen38-27b-dflash2` |
 | Toolkit | [MiaAI-Lab/Qwen3.8-27B-SGLang-DGX-Spark](https://github.com/MiaAI-Lab/Qwen3.8-27B-SGLang-DGX-Spark) @ `c90d8c34` |
 | Disk | ~110 GB |
 
@@ -44,16 +44,16 @@ kernel 6.17-nvidia, driver 580.173.02 / CUDA 13.0, Docker 29.2.1, 128 GB unified
 DGX OS ships CDI, not a registered Docker runtime — `docker info` showing only
 `runc` is normal and `--gpus all` still works.
 
-## 2. Build the image, fetch the weights
+## 2. Pull the image, fetch the weights
 
 ```bash
-./scripts/01-build-and-fetch.sh
+docker pull lmsysorg/sglang:dev-cu13-qwen38-27b-dflash2
+./scripts/01-build-and-fetch.sh    # weights; the build is now optional
 ```
 
-`lmsysorg/sglang:qwen38-27b-dflash2` **is not on Docker Hub.** SparkStation's
-`models.yaml` references it, but no released SGLang tag ships DFlash2 — you
-build it. The build also applies an NVFP4 `lm_head` patch; without it,
-draft-graph capture allocates ~2.5 GB and hard-reboots the machine.
+LMSYS published official DFlash2 images on 2026-08-22: `dev-cu13-qwen38-27b-dflash2`,
+`dev-qwen38-27b-dflash2`, `dev-cu12-qwen38-27b-dflash2`, arm64 included. Only the
+`qwen38-27b-dflash2` tag name is absent. The official image needs no `lm_head` patch.
 
 ## 3. Run standalone, get a baseline
 
@@ -119,9 +119,11 @@ co-limiting** — raising only the obvious one measures nothing.
 | **16** | — | **480.7** |
 | 32 | — | 469.8 |
 
-16 streams is a true optimum, not a plateau: TTFT p50 and max are identical
-there (0.68 s, zero queueing), while 24 and 32 are *slower* in aggregate with
-worst-case TTFT past 10 s.
+16 is the cap, not a hardware optimum. SGLang clamps
+`max_running_requests = max_mamba_cache_size / 5`, so the peak lands wherever the
+pool allows and the 24/32 rows are queueing against it. Pool 160 gives 606.4 tok/s
+at 32 streams, pool 240 gives 640.9 at 48 — but aggregate is bought with KV, so
+those are short-prompt figures.
 
 Leave `--max-total-tokens 1048576` in place: uncapping it grows the KV pool but
 nothing uses the space, and the lost headroom cost 18% at 32 streams.
@@ -193,7 +195,7 @@ Each of these cost real time.
 - **mem-fraction is not a perf lever here.** 0.82 / 0.85 / 0.90 all measure the
   same. Concurrency is bound by mamba slots, long context by prefill — never by
   memory capacity.
-- **The DFlash2 image doesn't exist upstream.** Build it; see step 2.
+- **The DFlash2 image now exists upstream** (`dev-cu13-qwen38-27b-dflash2`).
 - **HF cache symlinks inside the container mount break everything.** The
   container bind-mounts `~/.cache/huggingface`; symlinks *within* it point at
   host-only paths, so it re-downloads and dies with

--- a/patches/sparkstation-models.yaml.md
+++ b/patches/sparkstation-models.yaml.md
@@ -57,7 +57,8 @@ slots per request lands you at 12 instead of 16.
 
 | | pool 20 | pool 80 |
 |---|---:|---:|
-| GDN state allocation | 3.8 GB | **15.6 GB** |
+| GDN state allocation (`--mamba-ssm-dtype bfloat16`) | 3.8 GB | **15.6 GB** |
+| same, flag unset (resolves to `float32`) | 7.6 GB | 30.9 GB |
 | Free GPU memory after load | 38.1 GB | 20.6 GB |
 | Peak aggregate throughput | 190 tok/s | **480.7 tok/s** |
 | Single-stream decode | 63.1 tok/s | 60.0 tok/s |

--- a/results/REPRODUCTION.md
+++ b/results/REPRODUCTION.md
@@ -1,0 +1,66 @@
+# Independent reproduction
+
+Second DGX Spark GB10, 2026-08-23, box idle. Same `bench/perf.py`, same pins.
+Official image `lmsysorg/sglang:dev-cu13-qwen38-27b-dflash2`
+(`sha256:616a3e97f45191af975896cfa644279096cb31bd408a071c2e99ca7209c3cafe`),
+`--mamba-ssm-dtype bfloat16`, `--mem-fraction-static 0.85`, pool 80 / cap 16,
+pinned to `5-9,15-19`.
+
+The table below is at **draft=8**, matching the config these RESULTS.md rows
+were measured under. Draft=16 is a separate section.
+
+| Metric | RESULTS.md | Here |
+|---|---:|---:|
+| Time to first token | 190 ms | 200 ms |
+| Decode, thinking off (draft=8) | 61.3 tok/s | 60.3 |
+| Decode, thinking on | 46.7 tok/s | 47.3 |
+| Peak aggregate | 480.7 @ 16 | 474.5 @ 16 |
+| Prefill 9,698 tok | 2,173 tok/s | 2,215 |
+| Prefill 120,865 tok | 94.89 s | 88.68 s |
+| HumanEval, thinking off | 93.9% | 94.5% |
+| HumanEval, thinking on | 97.0% | 97.6% |
+
+Draft acceptance 6.28 of a block of 8. Both HumanEval deltas are one problem.
+Thinking-on failures were all truncation at the 16,384 cap, none wrong answers.
+
+Raising the GDN pool moves the peak: 606.4 tok/s at cap 32 (pool 160, 1.07M KV
+tokens), 640.9 at cap 48 (pool 240, 450k KV tokens). Zero queueing at the cap in
+both.
+
+## Draft tokens
+
+Re-run here as a within-boot A/B, same pool 80 / cap 16, only the flag differing.
+
+| draft | single | agg @16 | accept_len | RESULTS.md single |
+|---:|---:|---:|---:|---:|
+| 8 | 59.6 | 464.6 | 6.82 | 61.3 |
+| 16 | **84.4** | 393.6 | 9.25 | 78.6 |
+
+The direction reproduces and `accept_len` lands within 3% of yours at both
+values, so the mechanism is the same. The magnitude does not: **+41.6% here**
+against the +28% published. Our 84.4 is nearer the 85.7 you measured in-sweep
+than the 78.6 from the fresh boot, which suggests 78.6 is the low end of the
+boot-to-boot spread rather than the centre. The aggregate reversal reproduces
+too — draft=16 costs 15% aggregate at 16 streams.
+
+Quality is unchanged at the wider window, which had not been measured anywhere:
+
+| HumanEval | draft=8 | draft=16 | excl. truncation |
+|---|---:|---:|---:|
+| thinking off | 94.5% | 95.7% (157/164) | 96.9% |
+| thinking on | 97.6% | 96.3% (158/164) | 99.4% (158/159) |
+
++2 problems one way, -2 the other — inside the +/-2 band you document. So the
+speed is free: `accept_rate` falling 0.80 -> 0.57 costs throughput, not
+accuracy, since every draft is verified against the target model.
+
+One thing to flag rather than patch, since it is your new text: the methodology
+header now says 16 draft tokens, but TTFT, thinking-on, prose, concurrency,
+prefill and HumanEval were all measured at 8. It surfaces in the comparison
+row — `78.6 single / 480.7 aggregate` is two different configs, since draft=16
+puts aggregate at 384.8 and draft=8 puts single at 61.3.
+
+The base `lmsysorg/sglang:qwen38-27b` image cannot serve this: no
+`CandidateSelector`, `DFlash2DraftModel` unregistered, and its draft sampler
+multiplies against the packed NVFP4 `lm_head`. It falls back to an eager draft
+head and reaches 29.7 tok/s single-stream, 218.6 aggregate.

--- a/results/RESULTS.md
+++ b/results/RESULTS.md
@@ -7,8 +7,9 @@ kernel 6.17.0-1031-nvidia, aarch64. Driver 580.173.02, CUDA 13.0.
 Docker 29.2.1, nvidia-container-toolkit 1.20 via CDI.
 
 **Serving.** SGLang + `RadixArk/Qwen3.8-27B-NVFP4` + `z-lab/Qwen3.8-27B-DFlash2`
-(16 draft tokens), `--kv-cache-dtype fp8_e4m3`, 262144 context,
-`--mem-fraction-static 0.85`, CPU pinned to `5-9,15-19` (the Cortex-X5 cores).
+(16 draft tokens), `--kv-cache-dtype fp8_e4m3`, `--mamba-ssm-dtype bfloat16`,
+262144 context, `--mem-fraction-static 0.85`, CPU pinned to `5-9,15-19`
+(the Cortex-X5 cores).
 
 Throughput is code generation (LRUCache prompt) at temperature 0, counting
 `completion_tokens` over wall time.
@@ -184,7 +185,9 @@ appears to cover only part of the SoC. Don't use it for power budgeting.
 | 80 | 15.6 GB | 20.6 GB | **480.7 tok/s** |
 
 At 80 slots: `ssm_state` 5.70 GB + `intermediate_ssm_state_cache` 9.56 GB +
-conv caches 0.38 GB. On this hybrid architecture concurrency is bought with
+conv caches 0.38 GB — these hold only with `--mamba-ssm-dtype bfloat16`. Left
+unset the SSM state resolves to `float32`, which doubles this to 30.9 GB and
+leaves ~12 GB free. On this hybrid architecture concurrency is bought with
 mamba state, not KV cache — worth remembering when sizing a second model
 alongside it.
 


### PR DESCRIPTION
Reproduced your headline numbers on a second DGX Spark — 60.3 tok/s single-stream, 474.5 aggregate, HumanEval 94.5% / 97.6%. Full table in `results/REPRODUCTION.md`.

Three corrections:

- **Official DFlash2 images exist now.** `dev-cu13-qwen38-27b-dflash2` and siblings were published 2026-08-22, arm64 included, so the local build is optional. Only the `qwen38-27b-dflash2` tag name is absent.
- **The memory table needs `--mamba-ssm-dtype bfloat16`.** The checkpoint declares `float32`, which allocates 30.9 GB of GDN state at 80 slots instead of 15.6 GB.
- **16 streams is `max_mamba_cache_size / 5`, not a hardware optimum.** Pool 160 gives 606.4 tok/s at 32 streams; pool 240 gives 640.9 at 48. Aggregate is bought with KV, so those are short-prompt figures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)